### PR TITLE
Changed order of ADIF fields for logging to fix issue when sending log to CQRLOG

### DIFF
--- a/src/utils/adif.py
+++ b/src/utils/adif.py
@@ -104,7 +104,7 @@ class AdifLog():
         """
         Send a UDP adif message to a remote endpoint
         """
-        logging.debug(f"logging to {host}:{port} with data {msg}")
+        logging.error(f"logging to {host}:{port} with data {msg}")
 
         try:
             with socket.socket(socket.AF_INET, type) as sock:
@@ -130,8 +130,9 @@ class AdifLog():
         q_time_on = qso.time_on.strftime('%H%M%S')
         state = qso.state if qso.state else ''
 
-        adif = self._get_adif_field("band", band_name) + \
+        adif = \
             self._get_adif_field("call", qso.call) + \
+            self._get_adif_field("band", band_name) + \
             self._get_adif_field("name", qso.name if qso.name else '') + \
             self._get_adif_field("comment", qso.comment) + \
             self._get_adif_field("sig", qso.sig) + \

--- a/src/utils/adif.py
+++ b/src/utils/adif.py
@@ -104,7 +104,7 @@ class AdifLog():
         """
         Send a UDP adif message to a remote endpoint
         """
-        logging.error(f"logging to {host}:{port} with data {msg}")
+        logging.debug(f"logging to {host}:{port} with data {msg}")
 
         try:
             with socket.socket(socket.AF_INET, type) as sock:


### PR DESCRIPTION
The remote logging to CQRLOG was failing because CQRLOG was expecting the ADIF being sent to have a header or to have call as the first field. The building up of the adif has been update to have call first. I have only tested this with CQRLOG I am not sure it any other logging programs will have an issue with the change.