### PR TITLE
feat(wavelog): make station profile id configurable

### DIFF
--- a/src/@types/Config.d.ts
+++ b/src/@types/Config.d.ts
@@ -20,6 +20,7 @@ export interface UserConfig {
     stage_qsos: boolean,
     wavelog_url: string,
     wavelog_api_key: string,
+    wavelog_station_id: string,
     qrz_api_key: string,
     use_cw_offset: boolean,
     cw_offset_min: number,

--- a/src/api.py
+++ b/src/api.py
@@ -26,6 +26,7 @@ from programs.apis import PotaApi
 from programs import Program, SotaProgram, WwffProgram, PotaProgram, WwbotaProgram, NoProgram  # NOQA
 from utils.distance import Distance
 from utils.adif import AdifLog
+from utils.wavelog import get_stations
 from version import __version__
 
 logging = L.getLogger(__name__)
@@ -59,6 +60,7 @@ class JsApi:
             self.db.config.get_value('adif_port'),
             self.db.config.get_value('wl_url'),
             self.db.config.get_value('wl_api_key'),
+            self.db.config.get_value('wl_station_id'),
             self.db.config.get_value('qrz_api_key')
         )
         self.adif_log = LoggerInterface.get_logger(lp, __version__)
@@ -640,10 +642,34 @@ class JsApi:
             self.db.config.get_value('adif_port'),
             self.db.config.get_value('wl_url'),
             self.db.config.get_value('wl_api_key'),
+            self.db.config.get_value('wl_station_id'),
             self.db.config.get_value('qrz_api_key'),
         )
         self.adif_log = LoggerInterface.get_logger(lp, __version__)
         logging.debug(f"updating logger {self.adif_log}")
+
+    def get_wavelog_stations(self, url: str, api_key: str) -> str:
+        '''
+        Gets the list of station profiles from a Wavelog instance, so the
+        config UI can offer them in a drop down.
+
+        The url and api key are passed in from the UI rather than read from
+        the config, so the user can populate the drop down before saving.
+
+        :param str url: url of Wavelog instance (without endpoints appended)
+        :param str api_key: generated api key for wavelog API access
+
+        :returns str: json with either a `stations` list or an `error` string
+        '''
+        logging.debug(f"getting wavelog stations from {url}")
+
+        try:
+            stations = get_stations(url, api_key)
+        except Exception as ex:
+            logging.warning(f"error getting wavelog stations: {ex}")
+            return json.dumps({"error": str(ex)})
+
+        return json.dumps({"stations": stations})
 
     def set_mode_filter(self, modes: list[str]):
         logging.debug(f"api setting modes filter to: {modes}")

--- a/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigContextProvider.tsx
+++ b/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigContextProvider.tsx
@@ -23,6 +23,7 @@ const defData: UserConfig = {
     stage_qsos: true,
     wavelog_url: '',
     wavelog_api_key: '',
+    wavelog_station_id: '',
     qrz_api_key: '',
     use_cw_offset: false,
     cw_offset_min: 0,

--- a/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigModal.tsx
+++ b/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigModal.tsx
@@ -113,6 +113,7 @@ export default function ConfigModal() {
         config.stage_qsos = Number(getVar(cfg2, "stage_qsos")) != 0;
         config.wavelog_url = getVar(cfg2, 'wl_url');
         config.wavelog_api_key = getVar(cfg2, 'wl_api_key');
+        config.wavelog_station_id = getVar(cfg2, 'wl_station_id');
         config.qrz_api_key = getVar(cfg2, 'qrz_api_key');
         config.use_cw_offset = Number(getVar(cfg2, 'use_cw_offset')) != 0;
         config.cw_offset_min = Number(getVar(cfg2, 'cw_offset_min'));
@@ -150,6 +151,7 @@ export default function ConfigModal() {
         setVar(config2, "stage_qsos", config.stage_qsos.toString());
         setVar(config2, "wl_url", config.wavelog_url);
         setVar(config2, "wl_api_key", config.wavelog_api_key);
+        setVar(config2, "wl_station_id", config.wavelog_station_id);
         setVar(config2, "qrz_api_key", config.qrz_api_key);
         setVar(config2, "use_cw_offset", config.use_cw_offset.toString());
         setVar(config2, "cw_offset_min", config.cw_offset_min.toString());

--- a/src/components/AppMenu/MenuItems/SettingsMenu/Config/LoggerSettingsTab.tsx
+++ b/src/components/AppMenu/MenuItems/SettingsMenu/Config/LoggerSettingsTab.tsx
@@ -1,9 +1,64 @@
 import * as React from 'react';
-import { Checkbox, Divider, FormControlLabel, MenuItem, Select, Stack, TextField } from "@mui/material";
+import { Checkbox, CircularProgress, Divider, FormControl, FormControlLabel, FormHelperText, IconButton, InputLabel, MenuItem, Select, Stack, TextField, Tooltip } from "@mui/material";
+import RefreshIcon from '@mui/icons-material/Refresh';
 import { useConfigContext } from './ConfigContextProvider';
+
+interface WavelogStation {
+    station_id: string,
+    station_profile_name: string,
+    station_callsign: string,
+    station_active: string | null,
+}
 
 export default function LoggerSettingsTab() {
     const { config, setConfig } = useConfigContext();
+
+    const [stations, setStations] = React.useState<WavelogStation[]>([]);
+    const [loadingStations, setLoadingStations] = React.useState(false);
+    const [stationError, setStationError] = React.useState('');
+
+    const getStations = React.useCallback(async () => {
+        if (window.pywebview === undefined) return;
+
+        setLoadingStations(true);
+        setStationError('');
+
+        try {
+            const r = await window.pywebview.api.get_wavelog_stations(
+                config?.wavelog_url, config?.wavelog_api_key);
+            const result = JSON.parse(r);
+
+            if (result.error) {
+                setStations([]);
+                setStationError(result.error);
+                return;
+            }
+
+            const list = result.stations as WavelogStation[];
+            setStations(list);
+
+        } catch (e) {
+            setStations([]);
+            setStationError(`Could not read stations from Wavelog: ${e}`);
+        } finally {
+            setLoadingStations(false);
+        }
+    }, [config, setConfig]);
+
+    // fetch the station list when Wavelog becomes the selected logger and we
+    // already have something to authenticate with. deliberately not keyed on
+    // the url or key fields, or we would hit the API on every keystroke.
+    React.useEffect(() => {
+        if (config?.logger_type != 5) return;
+        if (!config?.wavelog_url || !config?.wavelog_api_key) return;
+
+        getStations();
+    }, [config?.logger_type]);
+
+    // keep a saved profile id selectable even before the list has loaded, so
+    // opening the config dialog offline does not silently blank the setting.
+    const savedId = config?.wavelog_station_id ?? '';
+    const isSavedIdKnown = stations.some(s => s.station_id === savedId);
 
     return (
         <div style={{ 'display': 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
@@ -78,6 +133,12 @@ export default function LoggerSettingsTab() {
                     to send data to the Wavelog instance. You can find this
                     in the Wavelog menus named &apos;API Keys&apos;
                 </p>
+                <p>
+                    Wavelog requires QSOs to name the station profile they belong to.
+                    Fill in the URL and API key, then press the refresh button to read
+                    your station profiles from Wavelog and pick the one you are
+                    operating from.
+                </p>
             </div>
 
             <div hidden={config?.logger_type != 6} className="modal-config-text">
@@ -102,19 +163,66 @@ export default function LoggerSettingsTab() {
             }
 
             {config?.logger_type == 5 &&
-                <Stack direction={'row'} spacing={1}>
-                    <TextField id="wl_url" label="Wavelog instance URL"
-                        value={config?.wavelog_url}
-                        fullWidth
-                        onChange={(e) => {
-                            setConfig({ ...config, wavelog_url: e.target.value });
-                        }} />
-                    <TextField id="wl_api_key" label="Wavelog API key"
-                        value={config?.wavelog_api_key}
-                        fullWidth
-                        onChange={(e) => {
-                            setConfig({ ...config, wavelog_api_key: e.target.value });
-                        }} />
+                <Stack direction={'column'} spacing={2}>
+                    <Stack direction={'row'} spacing={1}>
+                        <TextField id="wl_url" label="Wavelog instance URL"
+                            value={config?.wavelog_url}
+                            fullWidth
+                            onChange={(e) => {
+                                setConfig({ ...config, wavelog_url: e.target.value });
+                            }} />
+                        <TextField id="wl_api_key" label="Wavelog API key"
+                            value={config?.wavelog_api_key}
+                            fullWidth
+                            onChange={(e) => {
+                                setConfig({ ...config, wavelog_api_key: e.target.value });
+                            }} />
+                    </Stack>
+
+                    <Stack direction={'row'} spacing={1} alignItems={'center'}>
+                        <FormControl fullWidth error={stationError != ''}>
+                            <InputLabel id="wl-station-label">Wavelog station profile</InputLabel>
+                            <Select
+                                labelId="wl-station-label"
+                                id="wl_station_id"
+                                label="Wavelog station profile"
+                                value={savedId}
+                                onChange={(e) => {
+                                    setConfig({ ...config, wavelog_station_id: e.target.value.toString() });
+                                }}>
+                                {savedId != '' && !isSavedIdKnown &&
+                                    <MenuItem value={savedId}>
+                                        {`Profile ${savedId}`}
+                                    </MenuItem>
+                                }
+                                {stations.map((s) => (
+                                    <MenuItem key={s.station_id} value={s.station_id}>
+                                        {`${s.station_id}: ${s.station_profile_name} (${s.station_callsign})`}
+                                        {s.station_active === '1' ? ' - active in Wavelog' : ''}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                            <FormHelperText>
+                                {stationError != ''
+                                    ? stationError
+                                    : 'QSOs are logged against this station profile.'}
+                            </FormHelperText>
+                        </FormControl>
+
+                        {loadingStations
+                            ? <CircularProgress size={24} />
+                            : <Tooltip title="Read station profiles from Wavelog">
+                                <span>
+                                    <IconButton
+                                        aria-label="refresh wavelog stations"
+                                        disabled={!config?.wavelog_url || !config?.wavelog_api_key}
+                                        onClick={getStations}>
+                                        <RefreshIcon />
+                                    </IconButton>
+                                </span>
+                            </Tooltip>
+                        }
+                    </Stack>
                 </Stack>
             }
 

--- a/src/db/config_query.py
+++ b/src/db/config_query.py
@@ -225,6 +225,15 @@ class ConfigQuery:
             'editable': 'True'
         },
         {
+            'key': 'wl_station_id',
+            'val': '1',
+            'type': 'string',
+            'description': 'Wavelog station profile id to log QSOs against',
+            'group': 'wavelog',
+            'enabled': 'True',
+            'editable': 'True'
+        },
+        {
             'key': 'qrz_api_key',
             'val': '',
             'type': 'string',

--- a/src/loggers/logger_interface.py
+++ b/src/loggers/logger_interface.py
@@ -30,6 +30,7 @@ class LoggerParams:
     adif_port: int
     wl_url: str
     wl_api_key: str
+    wl_station_id: str
     qrz_api_key: str
 
 
@@ -82,6 +83,7 @@ class LoggerInterface:
             port=config.adif_port,
             wl_url=config.wl_url,
             wl_api_key=config.wl_api_key,
+            wl_station_id=config.wl_station_id,
             qrz_api_key=config.qrz_api_key
         )
 

--- a/src/loggers/wavelog_logger.py
+++ b/src/loggers/wavelog_logger.py
@@ -9,12 +9,13 @@ class WavelogLogger(GenericFileLogger):
     def init_logger(self, **kwargs):
         self.url = kwargs['wl_url']
         self.api_key = kwargs['wl_api_key']
+        self.station_id = kwargs['wl_station_id']
         return super().init_logger(**kwargs)
 
     def log_qso(self, qso) -> str:
         adif = super().log_qso(qso)
 
-        send_adif(self.url, self.api_key, adif)
+        send_adif(self.url, self.api_key, adif, self.station_id)
 
         return adif
 

--- a/src/utils/wavelog.py
+++ b/src/utils/wavelog.py
@@ -10,13 +10,83 @@ WAVELOG_API_URL = ""
 WAVELOG_API_KEY = ""
 WL_API_LOG = "/index.php/api/qso/"
 WL_API_RIG = '/index.php/api/radio'
+WL_API_STATIONS = '/index.php/api/station_info/'
 RADIO_NAME = "HUNTERLOG"
 
-# Define required headers
 headers = {
     "Content-Type": "application/json",
     "Accept": "application/json"
 }
+
+
+def _endpoint(url: str, api_path: str) -> str:
+    '''
+    Joins the user configured Wavelog base url with an API path, tolerating a
+    trailing slash on the base url.
+
+    :param str url: url of Wavelog instance (without endpoints appended)
+    :param str api_path: one of the WL_API_* constants
+
+    :returns str: the full endpoint url
+    '''
+    if url.endswith('/'):
+        return url[:-1] + api_path
+
+    return url + api_path
+
+
+def get_stations(url: str, api_key: str) -> list:
+    '''
+    Gets the station profiles (aka station locations) belonging to the owner of
+    the given API key.
+
+    Wavelog serves this endpoint over GET with the API key embedded in the
+    path, so there is no JSON payload. A read only key is sufficient.
+
+    :param str url: url of Wavelog instance (without endpoints appended)
+    :param str api_key: generated api key for wavelog API access
+
+    :returns list: station profile dicts as returned by Wavelog. The keys used
+        by hunterlog are station_id, station_profile_name, station_callsign and
+        station_active.
+
+    :raises Exception: if the request fails or the response cannot be parsed
+    '''
+    if not url or not api_key:
+        raise Exception("Wavelog URL and API key must both be set")
+
+    endpoint = _endpoint(url, WL_API_STATIONS) + api_key
+
+    try:
+        response = requests.get(endpoint, headers=headers, timeout=10)
+    except requests.exceptions.RequestException as e:
+        log.error(f"An error occurred getting stations from: {url}",
+                  exc_info=e)
+        raise Exception(f"Could not reach Wavelog at {url}")
+
+    if response.status_code != 200:
+        log.warning(
+            f"Getting Wavelog stations failed with status \
+                code: {response.status_code} \
+                text: {response.text}")
+        raise Exception(
+            f"Wavelog returned status {response.status_code}. "
+            "Check the URL and that the API key is valid.")
+
+    try:
+        stations = json.loads(response.text)
+    except json.JSONDecodeError as e:
+        log.error("Could not parse Wavelog station_info response",
+                  exc_info=e)
+        raise Exception("Wavelog returned a response that was not JSON")
+
+    if not isinstance(stations, list):
+        log.warning(f"Unexpected station_info response: {response.text}")
+        raise Exception("Wavelog did not return a list of stations")
+
+    log.debug(f"got {len(stations)} station profiles from wavelog")
+
+    return stations
 
 
 def send_radio(url: str, api_key: str, freq_hz: str, mode: str):
@@ -32,10 +102,7 @@ def send_radio(url: str, api_key: str, freq_hz: str, mode: str):
 
     # Send the POST request
     try:
-        if url.endswith('/'):
-            endpoint = url[:-1] + WL_API_RIG
-        else:
-            endpoint = url + WL_API_RIG
+        endpoint = _endpoint(url, WL_API_RIG)
 
         response = requests.post(
             endpoint, json=radio_payload, headers=headers)
@@ -53,27 +120,27 @@ def send_radio(url: str, api_key: str, freq_hz: str, mode: str):
                   exc_info=e)
 
 
-def send_adif(url: str, api_key: str, adif: str):
+def send_adif(url: str, api_key: str, adif: str, station_id: str):
     '''
     Sends the adif string to the wavelog instance.
 
     :param str url: url of Wavelog instance (without endpoints appended)
     :param str api_key: generated api key for wavelog API access
     :param str adif: good adif
+    :param str station_id: the Wavelog station profile id to log the QSO
+        against. Wavelog requires this field, it does not fall back on the
+        currently active station profile.
     '''
 
     adif_payload = {
         "key": api_key,
-        "station_profile_id": "1",
+        "station_profile_id": station_id,
         "type": "adif",
         "string": adif
     }
 
     try:
-        if url.endswith('/'):
-            endpoint = url[:-1] + WL_API_LOG
-        else:
-            endpoint = url + WL_API_LOG
+        endpoint = _endpoint(url, WL_API_LOG)
 
         response = requests.post(
             endpoint, json=adif_payload, headers=headers)


### PR DESCRIPTION
The Wavelog logger hardcoded station_profile_id was hard-coded to 1, so any user whose target profile was not id 1 had QSOs silently filed under the wrong station. Wavelog treats station_profile_id as a required field and does not fall back on the currently active station profile.

Adds a wl_station_id config entry alongside the existing wl_url and wl_api_key, and a drop down in the logger settings that is populated from Wavelog's api/station_info endpoint. The endpoint is served over GET with the api key in the path and a read only key is sufficient.

The drop down marks whichever profile Wavelog reports as active. A saved id stays selectable even when the list cannot be loaded, so opening the config dialog offline does not blank the setting.

Default value is 1, matching the previous hardcoded behaviour, so existing installs keep working until the user picks a profile.

Fixes #158