### PR TITLE
feat: optionally match hunted spots on base callsign

### DIFF
--- a/src/@types/Config.d.ts
+++ b/src/@types/Config.d.ts
@@ -15,6 +15,7 @@ export interface UserConfig {
     qth_string: string,
     rig_if_type: string,
     include_rst: boolean,
+    hunted_use_basecall: boolean,
     enabled_progs: string
     scan_wait_time: number,
     stage_qsos: boolean,

--- a/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigContextProvider.tsx
+++ b/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigContextProvider.tsx
@@ -18,6 +18,7 @@ const defData: UserConfig = {
     qth_string: '',
     rig_if_type: '',
     include_rst: false,
+    hunted_use_basecall: false,
     enabled_progs: '',
     scan_wait_time: 5,
     stage_qsos: true,

--- a/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigModal.tsx
+++ b/src/components/AppMenu/MenuItems/SettingsMenu/Config/ConfigModal.tsx
@@ -108,6 +108,7 @@ export default function ConfigModal() {
         config.rig_if_type = getVar(cfg2, 'rig_if_type');
         config.logger_type = Number(getVar(cfg2, "logger_type"));
         config.include_rst = Number(getVar(cfg2, "include_rst")) != 0;
+        config.hunted_use_basecall = Number(getVar(cfg2, "hunted_use_basecall")) != 0;
         config.enabled_progs = getVar(cfg2, 'enabled_programs');
         config.scan_wait_time = Number(getVar(cfg2, "scan_wait_time"));
         config.stage_qsos = Number(getVar(cfg2, "stage_qsos")) != 0;
@@ -147,6 +148,7 @@ export default function ConfigModal() {
         setVar(config2, "qth_string", config.qth_string);
         setVar(config2, "rig_if_type", config.rig_if_type);
         setVar(config2, "include_rst", config.include_rst.toString());
+        setVar(config2, "hunted_use_basecall", config.hunted_use_basecall.toString());
         setVar(config2, "enabled_programs", config.enabled_progs);
         setVar(config2, "scan_wait_time", config.scan_wait_time.toString());
         setVar(config2, "stage_qsos", config.stage_qsos.toString());

--- a/src/components/AppMenu/MenuItems/SettingsMenu/Config/GeneralSettingsTab.tsx
+++ b/src/components/AppMenu/MenuItems/SettingsMenu/Config/GeneralSettingsTab.tsx
@@ -98,6 +98,22 @@ export default function GeneralSettingsTab() {
                                 }} />
                         } />
                 </Stack>
+                <p>
+                    When matching hunted spots, ignore portable suffixes and
+                    country prefixes, so SM6KZW and SM6KZW/P count as the same
+                    station, as do SM6KZW and LA/SM6KZW.
+                </p>
+                <Stack direction={'row'}>
+                    <FormControlLabel label="Match hunted on base callsign"
+                        control={
+                            <Checkbox checked={config.hunted_use_basecall}
+                                inputProps={{ 'aria-label': 'controlled' }}
+                                onChange={(e) => {
+                                    const val = Boolean(e.target.checked);
+                                    setConfig({ ...config, hunted_use_basecall: val });
+                                }} />
+                        } />
+                </Stack>
             </Stack>
         </>
     )

--- a/src/db/config_query.py
+++ b/src/db/config_query.py
@@ -376,6 +376,15 @@ class ConfigQuery:
             'group': 'wsjtx',
             'enabled': 'True',
             'editable': 'True'
+        },
+        {
+            'key': 'hunted_use_basecall',
+            'val': '0',
+            'type': 'bool',
+            'description': 'Match hunted spots on base callsign, ignoring portable suffixes and country prefixes',  # noqa: E501
+            'group': 'general',
+            'enabled': 'True',
+            'editable': 'True'
         }
     ]
 

--- a/src/db/qso_query.py
+++ b/src/db/qso_query.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import scoped_session
 
 from db.models.qsos import Qso, QsoSchema
 from bands import Bands, get_band, bandLimits, bandNames
+from utils.callsigns import get_basecall
 
 log = logging.getLogger(__name__)
 
@@ -166,61 +167,93 @@ class QsoQuery:
     def get_spot_hunted_flag(self,
                              activator: str,
                              freq: str,
-                             ref: str) -> bool:
+                             ref: str,
+                             use_basecall: bool = False) -> bool:
         '''
-        Gets the flag indicating if a given spot has been hunted already today
+        Determine whether this activator has already been worked at this
+        reference, on this band, today.
 
-        :param str activator: activators callsign
-        :param str freq: frequency in MHz
-        :param str ref: the park reference (ex K-7465)
-        :returns true if the spot has already been hunted
+        :param str activator: the spotted callsign
+        :param str freq: spot frequency, used to derive the band
+        :param str ref: the park or summit reference
+        :param bool use_basecall: when True, compare base callsigns so that
+            portable suffixes and country prefixes do not create duplicates,
+            eg. SM6KZW and SM6KZW/P, or SM6KZW and LA/SM6KZW
         '''
         now = datetime.now(timezone.utc)
         band = get_band(freq)
-        # logging.debug(f"using band {band} for freq {freq}")
 
         if band is not None:
             terms = QsoQuery.get_band_lmt_terms(band, Qso.freq)
         else:
             terms = [1 == 1]
 
-        sql = sa.select(sa.func.count()) \
-            .where(Qso.call == activator) \
+        if not use_basecall:
+            sql = sa.select(sa.func.count()) \
+                .where(Qso.call == activator) \
+                .where(Qso.sig_info == ref) \
+                .where(Qso.time_on > now.date()) \
+                .where(sa.and_(*terms))
+
+            return self.session.scalar(sql) > 0
+
+        # Base call equality cannot be expressed in SQL here, so narrow the
+        # query as far as possible and finish the comparison in Python.
+        # get_basecall() always returns either the whole callsign or one of
+        # its slash separated segments, so every callsign that normalises to
+        # basecall must contain it as a substring. The LIKE below is
+        # therefore a safe superset and cannot produce false negatives.
+        basecall = get_basecall(activator)
+
+        sql = sa.select(Qso.call) \
+            .where(Qso.call.contains(basecall)) \
             .where(Qso.sig_info == ref) \
             .where(Qso.time_on > now.date()) \
             .where(sa.and_(*terms))
 
-        flag = self.session.scalar(sql) > 0
+        for row in self.session.execute(sql).all():
+            if get_basecall(row.call) == basecall:
+                return True
 
-        return flag
+        return False
 
-    def get_spot_hunted_bands(self, activator: str, ref: str) -> str:
+    def get_spot_hunted_bands(self,
+                              activator: str,
+                              ref: str,
+                              use_basecall: bool = False) -> str:
         '''
-        Gets the string of all hunted bands, this spot has been hunted today
+        Return a comma separated list of the bands on which this activator
+        has been worked at this reference today.
 
-        :param str activator: activators callsign
-        :param str ref: park reference
-        :returns list of hunted bands for today
+        :param str activator: the spotted callsign
+        :param str ref: the park or summit reference
+        :param bool use_basecall: when True, compare base callsigns so that
+            portable suffixes and country prefixes do not create duplicates
         '''
         now = datetime.now(timezone.utc)
         result = ""
         hunted_b = []
 
+        basecall = get_basecall(activator)
+
+        if use_basecall:
+            # See get_spot_hunted_flag: this LIKE is a superset of the base
+            # call match and is narrowed exactly in the loop below.
+            call_term = Qso.call.contains(basecall)
+        else:
+            call_term = Qso.call == activator
+
         sql = sa.select(Qso.call, Qso.sig_info, Qso.time_on, Qso.freq) \
-            .where(Qso.call == activator) \
+            .where(call_term) \
             .where(Qso.sig_info == ref) \
             .where(Qso.time_on > now.date())
 
         qsos = self.session.execute(sql).all()
 
-        # optimized away
-        # qsos = self.session.query(Qso) \
-        #     .filter(Qso.call == activator,
-        #             Qso.sig_info == ref,
-        #             Qso.time_on > now.date()) \
-        #     .all()
-
         for q in qsos:
+            if use_basecall and get_basecall(q.call) != basecall:
+                continue
+
             band = get_band(q.freq)
             if band is None:
                 logging.warning(f"unknown band for freq {q.freq}")

--- a/src/programs/program.py
+++ b/src/programs/program.py
@@ -176,11 +176,14 @@ class Program(ABC):
         count = self.db.qsos.get_op_qso_count(to_add.activator)
         to_add.op_hunts = count
 
+        use_basecall = self.db.config.get_value('hunted_use_basecall')
+
         hunted = self.db.qsos.get_spot_hunted_flag(
-            to_add.activator, to_add.frequency, to_add.reference)
+            to_add.activator, to_add.frequency, to_add.reference,
+            use_basecall)
 
         bands = self.db.qsos.get_spot_hunted_bands(
-            to_add.activator, to_add.reference)
+            to_add.activator, to_add.reference, use_basecall)
 
         to_add.hunted = hunted
         to_add.hunted_bands = bands

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -37,16 +37,20 @@ class Metadata:
 
         spots_parsed = program.parse_spots_data(spots)
 
+        # read once for the whole batch, not per spot, to keep this loop
+        # down to the queries it already makes
+        use_basecall = self._db.config.get_value('hunted_use_basecall')
+
         for s in spots_parsed:
             # log.debug(f"parsed spot for metadata {s}")
 
             hunt_count = self._db.parks.get_park_hunts(s.reference)
             op_count = self._db.qsos.get_op_qso_count(s.activator)
             hunted = self._db.qsos.get_spot_hunted_flag(
-                s.activator, s.frequency, s.reference)
+                s.activator, s.frequency, s.reference, use_basecall)
 
             bands = self._db.qsos.get_spot_hunted_bands(
-                s.activator, s.reference)
+                s.activator, s.reference, use_basecall)
 
             is_hidden = self._db.hidden_spots.is_hidden(
                 s.activator, s.reference, s.spotTime)
@@ -83,12 +87,14 @@ class Metadata:
                 f"no metadata to update for: {spot_id} {call} {reference}")
             return
 
+        use_basecall = self._db.config.get_value('hunted_use_basecall')
+
         meta.park_hunts = self._db.parks.get_park_hunts(reference)
         meta.op_hunt = self._db.qsos.get_op_qso_count(call)
         meta.hunted_flag = self._db.qsos.get_spot_hunted_flag(
-            call, freq, reference)
+            call, freq, reference, use_basecall)
         meta.hunted_bands = self._db.qsos.get_spot_hunted_bands(
-            call, reference)
+            call, reference, use_basecall)
 
     def update_hidden(self, spot_id: int, is_hidden: bool):
         meta = self._data.get(spot_id)


### PR DESCRIPTION
Fixes #160.

Per your answers in the issue: normalisation is behind a new setting,
`hunted_use_basecall`, which defaults to off so nobody's current
behaviour changes. Targeting `dev10` as you asked.

## What changed

`get_spot_hunted_flag` and `get_spot_hunted_bands` take a new
`use_basecall` parameter, defaulting to `False`. When it is `False` the
existing queries run exactly as before.

When it is `True`, base callsigns are compared using the existing
`utils.callsigns.get_basecall`. Since that function always returns
either the whole callsign or one of its slash separated segments, every
callsign that normalises to a given base call must contain it as a
substring. The query therefore keeps a `LIKE` on the base call as a
guaranteed superset and finishes the exact comparison in Python, so it
does not degrade into an unfiltered scan.

The setting is read once per batch in `Metadata.add_spots`, not per
spot, so the loop keeps the same number of queries per spot as before.
`Metadata.update_metadata` and `Program.update_spot_metadata` read it at
their own call sites, matching how other cross cutting flags are handled
in the codebase.

## Settings UI

A checkbox on the General tab, following the `include_rst` pattern.

## Testing

Verified with a standalone script against an in-memory database, with
`SM6KZW/P` and `LA/SM6KZW` logged at a test reference:

| spotted | off | on |
| --- | --- | --- |
| SM6KZW | false | true |
| SM6KZW/P | true | true |
| LA/SM6KZW | true | true |
| LA/SM6KZW/P | false | true |
| SE6S | false | false |
| SE6S/P | false | false |

I did not include the script since the repo has no test directory or
test dependency yet. Happy to add it under `tests/` if you want it.